### PR TITLE
[241106] PGS 카펫 - 소연

### DIFF
--- a/soyeon/PGS/카펫.java
+++ b/soyeon/PGS/카펫.java
@@ -1,0 +1,22 @@
+package soyeon.PGS;
+
+public class 카펫 {
+    public int[] solution(int brown, int yellow) {
+        int[] answer = new int[2];
+        
+        int total = yellow + brown;
+        
+        for(int i = 3; i < total; i++){
+            for(int j = i; j < total; j++){                
+                if((i * j == total) && ((i - 2) * (j - 2) == yellow)){
+                    // 가로가 더 커야 하니까 순서 바꾸기
+                    answer[0] = j;
+                    answer[1] = i;
+                    return answer;
+                }
+            }
+        }
+        
+        return answer;
+    }
+}


### PR DESCRIPTION
### 📌 문제 이름
- #9 
<br/>

### 📌 문제 정의
- **문제**
    - 주어진 갈색 격자의 수와 노란색 격자의 수를 이용해서 전체 카펫의 가로와 세로 크기 구하기
- **Input**
    - 갈색 격자의 수 `brown` (8 ~ 5,000)
    - 노란색 격자의 수 `yellow` (1 ~ 2,000,000)
- **Output**
    - 전체 카펫의 가로 세로 크기를 담은 배열
- **제한사항**
    - 카펫의 가로 길이는 세로 길이와 같거나, 세로 길이보다 길어야 함
<br/>

### 📌 핵심 포인트
- **전체 격자의 수 계산하기**
    - `brown + yellow`를 통해 전체 격자의 개수 `total`을 구함 
- **가로, 세로 탐색**
    - 두 개의 반복문을 통해 카펫의 `height`와 `width`를 찾으며, `height * width = total`인 경우만을 후보로 고려함
- **노란색 영역 검증**
    - 전체 영역의 네 모서리를 제외한 `width - 2`, `height - 2`가 각각 노란색 영역의 가로 세로임을 이용함
    - `(height - 2) * (width - 2) == yellow` 조건을 통해, 후보를 통해 얻은 노란색 격자의 개수와 실제 노란색 격자의 개수가 같은지 비교함
<br/>

### 📌 특이사항
- 가로 세로의 길이가 3보다 작으면 yellow가 0개일 거니까 3부터 반복문 시작함
- 반복문 조건식 yellow, brown 다 해봐도 안 되길래 total 해봤는데 됨 😓