### PR TITLE
[241110] PGS 짝지어 제거하기 - 소연

### DIFF
--- a/soyeon/PGS/짝지어_제거하기.java
+++ b/soyeon/PGS/짝지어_제거하기.java
@@ -1,0 +1,43 @@
+import java.util.Stack;
+
+public class 짝지어_제거하기 {
+
+    /*
+     * 정확성 테스트는 통과하지만, 효율성 테스트에서 시간 초과 발생
+     * 
+     * public int solution(String s)
+     * {
+     *   StringBuilder sb = new StringBuilder(s);
+     *   boolean removed;
+     *   
+     *   do{
+     *       removed = false;
+     *       for(int i = 1; i < sb.length(); i++){
+     *           if(sb.charAt(i) == sb.charAt(i - 1)){
+     *               sb.delete(i - 1, i + 1);
+     *               removed = true;
+     *               break;
+     *           }
+     *       }
+     *   } while(removed);
+     *   
+     *   return sb.length() == 0 ? 1 : 0;
+     * }
+     */
+
+    public int solution(String s)
+    {
+        Stack<Character> stack = new Stack<>();
+        
+        for(char ch : s.toCharArray()){
+            if(!stack.isEmpty() && stack.peek() == ch){
+                stack.pop();
+            }
+            else{
+                stack.push(ch);
+            }
+        }
+        
+        return stack.isEmpty() ? 1 : 0;
+    }
+}


### PR DESCRIPTION
### 📌 문제 이름
- #23 
<br/>

### 📌 문제 정의
- **문제**
    - 알파벳 소문자로 이루어진 문자열에서 같은 알파벳이 2개 붙어 있는 짝을 찾아 제거한 후, 앞뒤로 문자열을 이어 붙이는 과정을 반복해서 문자열을 모두 제거하면 1을, 아니면 0을 반환하기
- **Input**
    - 알파벳 소문자로 이루어진 문자열 `s`
- **Output**
    - 주어진 과정을 모두 수행할 수 있으면 `1`, 아니면 `0` 반환
<br/>

### 📌 핵심 포인트
- **스택을 이용한 중복 문자 제거**
    - 문자열의 각 문자를 스택에 순차적으로 넣으면서, **스택의 최상단 문자와 현재 문자가 같은 경우** 스택에서 최상단 문자를 제거 (`pop`)함
    - 연속된 중복 문자는 바로 제거되므로, 중복되지 않은 문자만 스택에 남게 됨
- **스택이 비어 있는지 확인**
    - 스택이 비어 있으면 모든 문자가 쌍을 이루어 제거된 것이므로 `1`을 반환함
    - 스택이 비어있지 않으면 제거되지 않은 문자가 남아있는 것이므로 `0`을 반환함
- **효율성 고려**
    - 스택으로 접근하면 문자열을 한 번만 순회하며, 각 문자는 스택에서 한 번 들어가거나 나오므로 시간 복잡도는 `O(n)`
<br/>

### 📌 특이사항
- **`StringBuilder`를 이용한 초기 풀이 방식**
    - 문자열을 `StringBuilder`로 변환하여, 연속된 중복 문자가 발견될 때마다 제거하는 방식으로 접근했었음
    - `removed` 플래그를 사용해서 중복된 문자 쌍이 제거되면, 다시 처음부터 문자열을 순회하는 `do-while` 구조를 사용했음
    - 근데 이렇게 하면 문자열이 길어질수록 `O(n^2)`에 가까운 시간 복잡도가 발생해서 효율성 테스트에서 시간 초과가 발생함 🥲
    - 따라서 초기 방식의 시간 복잡도 문제를 해결하기 위해 문자열을 한 번만 순회하면서도, 연속된 중복 문자 제거가 가능한 스택을 사용한 방식으로 풀이 변경 ✨