### PR TITLE
[241113] PGS 짝지어 제거하기 - 윤교

### DIFF
--- a/yoonkyo/PGS/짝지어_제거하기.py
+++ b/yoonkyo/PGS/짝지어_제거하기.py
@@ -1,0 +1,27 @@
+def solution(s):
+    # if len(s) == 0:
+    #     return 1    # 완료
+    # elif len(s) == 1:
+    #     return 0    # 문자열 길이가 1이면 불가능
+    # for i in range(len(s) - 1):
+    #     if s[i] == s[i + 1]:
+    #         return solution(s[:i] + s[i + 2:])
+    # return 0        # 맞는 문자열 없는경우
+    
+    arr = list(s)   # 스택 생성
+    end = -1        # top을 가르키는 ptr
+
+    for i in range(len(arr)):
+        if end != -1 and arr[end] == arr[i]:
+            # pop
+            end -= 1
+        else:
+            # push
+            end += 1
+            arr[end] = arr[i]
+        i += 1
+        
+    if end == -1:   # stack empty?
+        return 1
+    else:
+        return 0


### PR DESCRIPTION
### 📌 문제 이름
- #23 
<br/>

### 📌 문제 정의
- **문제**
    - 알파벳 소문자로 이루어진 문자열에서 같은 알파벳이 2개 붙어 있는 짝을 찾아 제거한 후, 앞뒤로 문자열을 이어 붙이는 과정을 반복해서 문자열을 모두 제거하면 1을, 아니면 0을 반환하기
- **Input**
    - 알파벳 소문자로 이루어진 문자열 `s`
- **Output**
    - 주어진 과정을 모두 수행할 수 있으면 `1`, 아니면 `0` 반환
<br/>

### 📌 핵심 포인트
- **스택을 이용한 중복 문자 제거**
    - 문자열의 각 문자를 스택에 순차적으로 넣으면서, **스택의 최상단 문자와 현재 문자가 같은 경우** 스택에서 최상단 문자를 제거 (`pop`)함
    - 연속된 중복 문자는 바로 제거되므로, 중복되지 않은 문자만 스택에 남게 됨
- **스택이 비어 있는지 확인**
    - stack의 top을 가르키는 ptr인 `end`가 -1이면 empty
- **효율성 고려**
    - 재귀로 접근하면, 문자열을 slicing하는 과정에서 문자열을 순회하므로 `O(n^2)`의 복잡도가 발생함
    - 스택으로 접근하면, 메모리 사용량은 2배가 되지만 `O(n)`의 복잡도로 해결 가능함
<br/>

### 📌 특이사항
- **`Recursion`을 이용한 초기 풀이 방식**
   - 문자열을 제거하고 다시 함수를 호출하는 재귀방식을 사용했으나, 역시나 시간초과!
   - 따라서, stack의 구조를 사용함.