### PR TITLE
[250106] PGS 바탕화면 정리 - 윤교

### DIFF
--- a/yoonkyo/PGS/바탕화면_정리.py
+++ b/yoonkyo/PGS/바탕화면_정리.py
@@ -1,0 +1,12 @@
+def solution(wallpaper):
+    # 파일 위치
+    x = []
+    y = []
+    
+    for i in range(len(wallpaper)):
+        for j in range(len(wallpaper[0])):
+            if(wallpaper[i][j] == '#'):
+                x.append(i)
+                y.append(j)
+    
+    return [min(x), min(y), max(x)+1, max(y)+1]


### PR DESCRIPTION
### 📌 문제 이름
- #35 
<br/>

### 📌 문제 정의
- **문제**
    - 주어진 문자열 배열 `wallpaper`에서 #로 표시된 파일의 영역을 찾고, 이를 정리하여 최소한의 바탕화면 영역 좌표를 반환하는 문제
- **Input**
    - `wallpaper[]`로 한 변이 50이하인 직사각형 좌표
- **Output**
    - `[ldx, ldy, rdx, rdy]`로 반환
    - 각각 드래그 시작 지점, 끝 지점의 x, y좌표를 뜻함
<br/>

### 📌 핵심 포인트
- `wallpaper[]`를 완전 탐색하며 #의 index를 저장
- `[min(x), min(y), max(x), max(y)]`가 정답이 될... 줄 알았으나 max에는 +1을 해야하는 걸 컨닝함 ㅋ😊
<br/>